### PR TITLE
Add cniVersion to calico cni conf

### DIFF
--- a/templates/10-calico.conflist
+++ b/templates/10-calico.conflist
@@ -1,5 +1,6 @@
 {
   "name": "calico-k8s-network",
+  "cniVersion": "0.3.1",
   "plugins": [
     {
       "type": "calico",


### PR DESCRIPTION
When the cniVersion field is omitted, we hit this bug in Multus: intel/multus-cni#289 (which isn't really about SR-IOV as far as I can tell).

Multus needs more design work before we merge in the main stuff, but I figure there's no harm in merging this one in advance.