### PR TITLE
switch images to the canonical registry

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,12 +2,12 @@ options:
   calico-node-image:
     type: string
     # Please refer to layer-canal/versioning.md before changing the version below.
-    default: docker.io/calico/node:v3.6.1
+    default: image-registry.canonical.com:5000/cdk/calico/node:v3.6.1
     description: |
       The image id to use for calico/node.
   calico-policy-image:
     type: string
-    default: docker.io/calico/kube-controllers:v3.6.1
+    default: image-registry.canonical.com:5000/cdk/calico/kube-controllers:v3.6.1
     description: |
       The image id to use for calico/kube-controllers.
   ipip:


### PR DESCRIPTION
Images are present in the registry:

https://image-registry.canonical.com:5000/v2/cdk/calico/node/tags/list
https://image-registry.canonical.com:5000/v2/cdk/calico/kube-controllers/tags/list

Use 'em.