### PR TITLE
Bump to calico 3.10.1

### DIFF
--- a/build-calico-resource.sh
+++ b/build-calico-resource.sh
@@ -10,8 +10,8 @@ set -eux
 
 # Supported calico architectures
 arches="amd64 arm64"
-calicoctl_version="v3.6.1"
-calico_cni_version="v3.6.1"
+calicoctl_version="v3.10.1"
+calico_cni_version="v3.10.1"
 
 function fetch_and_validate() {
   # fetch a binary and make sure it's what we expect (executable > 20MB)

--- a/config.yaml
+++ b/config.yaml
@@ -2,12 +2,12 @@ options:
   calico-node-image:
     type: string
     # Please refer to layer-canal/versioning.md before changing the version below.
-    default: rocks.canonical.com:443/cdk/calico/node:v3.6.1
+    default: rocks.canonical.com:443/cdk/calico/node:v3.10.1
     description: |
       The image id to use for calico/node.
   calico-policy-image:
     type: string
-    default: rocks.canonical.com:443/cdk/calico/kube-controllers:v3.6.1
+    default: rocks.canonical.com:443/cdk/calico/kube-controllers:v3.10.1
     description: |
       The image id to use for calico/kube-controllers.
   ipip:

--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -7,7 +7,7 @@ import calico_upgrade
 
 from conctl import getContainerRuntimeCtl
 from socket import gethostname
-from subprocess import check_call, check_output, CalledProcessError
+from subprocess import check_call, check_output, CalledProcessError, STDOUT
 
 from charms.leadership import leader_get, leader_set
 from charms.reactive import when, when_not, when_any, set_state, remove_state
@@ -579,7 +579,7 @@ def calicoctl(*args):
     env = os.environ.copy()
     env.update(get_calicoctl_env())
     try:
-        return check_output(cmd, env=env)
+        return check_output(cmd, env=env, stderr=STDOUT)
     except CalledProcessError as e:
         log(e.output)
         raise

--- a/templates/policy-controller.yaml
+++ b/templates/policy-controller.yaml
@@ -7,7 +7,7 @@ metadata:
 # Include a clusterrole for the kube-controllers component,
 # and bind it to the calico-kube-controllers serviceaccount.
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-kube-controllers
 rules:
@@ -35,7 +35,7 @@ rules:
       - list
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-kube-controllers
 roleRef:
@@ -100,7 +100,7 @@ spec:
             path: /opt/calicoctl
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-node
 rules:
@@ -119,7 +119,7 @@ rules:
     verbs:
       - patch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: calico-node
@@ -132,7 +132,7 @@ subjects:
   name: calico-node
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: namespace-reader
@@ -141,7 +141,7 @@ rules:
   resources: ["namespaces"]
   verbs: ["get"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: nodes-namespace-reader


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-calico/+bug/1854977 for Calico

Tested by deploying this with `cs:~containers/kubernetes-calico` from edge. I ran validation and it passed:

```
$ pytest -s --no-print-logs -m 'not slow' --controller aws-vpc-0b87e1fedaca950f8 --model calico validation.py
...
=============================== warnings summary ===============================
jobs/integration/validation.py::test_dashboard
jobs/integration/validation.py::test_dashboard
jobs/integration/validation.py::test_kubelet_anonymous_auth_disabled
jobs/integration/validation.py::test_kubelet_anonymous_auth_disabled
  /usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:851: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    InsecureRequestWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===== 19 passed, 4 skipped, 1 deselected, 4 warnings in 1553.85s (0:25:53) =====
```