### PR TITLE
Add support for series upgrade

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -1,0 +1,22 @@
+name: Run tests with Tox
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install Tox and any other packages
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e py  # Run tox using the version of Python in `PATH`

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.tox/
+__pycache__/
+*.pyc

--- a/layer.yaml
+++ b/layer.yaml
@@ -3,4 +3,5 @@ includes:
   - 'interface:kubernetes-cni'
   - 'layer:basic'
   - 'layer:leadership'
+  - 'layer:status'
 repo: https://github.com/juju-solutions/layer-calico.git

--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -567,6 +567,8 @@ def ready():
         'calico.cni.configured', 'calico.bgp.globals.configured',
         'calico.node.configured', 'calico.bgp.peers.configured'
     ]
+    if is_state('upgrade.series.in-progress'):
+        return
     for precondition in preconditions:
         if not is_state(precondition):
             return

--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -77,6 +77,11 @@ def upgrade_charm():
         })
 
 
+@hook('pre-series-upgrade')
+def pre_series_upgrade():
+    status_set('blocked', 'Series upgrade in progress')
+
+
 @when('leadership.is_leader', 'leadership.set.calico-v3-data-migration-needed',
       'etcd.available', 'calico.etcd-credentials.installed')
 def upgrade_v3_migrate_data():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import charms.unit_test
+
+
+charms.unit_test.patch_reactive()
+charms.unit_test.patch_module('conctl')
+charms.unit_test.patch_module('charms.leadership')

--- a/tests/test_calico.py
+++ b/tests/test_calico.py
@@ -1,7 +1,18 @@
+from collections import defaultdict
+from charmhelpers.core.hookenv import is_leader  # patched
+from charmhelpers.core.host import service_running  # patched
 from reactive import calico
 
 
 def test_series_upgrade():
-    assert calico.status_set.call_count == 0
-    calico.pre_series_upgrade()
-    assert calico.status_set.call_count == 1
+    flags = defaultdict(lambda: False)
+    flags['upgrade.series.in-progress'] = True
+    is_leader.return_value = False
+    service_running.return_value = True
+    assert calico.status.blocked.call_count == 0
+    assert calico.status.waiting.call_count == 0
+    assert calico.status.active.call_count == 0
+    calico.ready()
+    assert calico.status.blocked.call_count == 1
+    assert calico.status.waiting.call_count == 0
+    assert calico.status.active.call_count == 0

--- a/tests/test_calico.py
+++ b/tests/test_calico.py
@@ -1,0 +1,7 @@
+from reactive import calico
+
+
+def test_series_upgrade():
+    assert calico.status_set.call_count == 0
+    calico.pre_series_upgrade()
+    assert calico.status_set.call_count == 1

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,6 @@
 skipsdist = True
 envlist = lint,py3
 
-[tox:travis]
-3.5: lint,py3
-3.6: lint,py3
-3.7: lint,py3
-
 [testenv]
 basepython = python3
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+skipsdist = True
+envlist = lint,py3
+
+[tox:travis]
+3.5: lint,py3
+3.6: lint,py3
+3.7: lint,py3
+
+[testenv]
+basepython = python3
+setenv =
+    PYTHONPATH={toxinidir}:{toxinidir}/lib
+deps =
+    pyyaml
+    pytest
+    flake8
+    ipdb
+    git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
+commands = pytest --tb native -s {posargs}
+
+[testenv:lint]
+envdir = {toxworkdir}/py3
+commands = flake8 {toxinidir}/lib {toxinidir}/reactive {toxinidir}/tests


### PR DESCRIPTION
We can't actually pause the service because the series upgrade hooks run on the subordinates before the principal so doing so could interfere with the pod drain process. So instead, we just set a status to let the Juju admin know that it's ok to proceed.

Part of https://bugs.launchpad.net/charm-calico/+bug/1869944