### PR TITLE
Add mtu config option to Calico charm

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,12 @@ options:
     default: Never
     description: |
       IPIP mode. Must be one of "Always", "CrossSubnet", or "Never".
+  veth-mtu:
+    type: int
+    default: 
+    description: |
+      Set veth MTU size for multiple scenarios. Users should follow instructions:
+      https://docs.projectcalico.org/networking/mtu
   nat-outgoing:
     type: boolean
     default: true

--- a/templates/10-calico.conflist
+++ b/templates/10-calico.conflist
@@ -9,6 +9,9 @@
       "etcd_cert_file": "{{ etcd_cert_path }}",
       "etcd_ca_cert_file": "{{ etcd_ca_path }}",
       "log_level": "info",
+      {% if mtu -%}
+      "mtu": {{ mtu }},
+      {%- endif %}
       "ipam": {
           "type": "calico-ipam"
       },

--- a/templates/calico-node.service
+++ b/templates/calico-node.service
@@ -23,6 +23,9 @@ ExecStart=/usr/local/sbin/charm-env --charm calico conctl run \
   --env IP6= \
   --env CALICO_NETWORKING_BACKEND=bird \
   --env FELIX_DEFAULTENDPOINTTOHOSTACTION=ACCEPT \
+  {% if mtu -%}
+  --env FELIX_IPINIPMTU={{ mtu }} \
+  {%- endif %}
   --mount /lib/modules:/lib/modules \
   --mount /var/run/calico:/var/run/calico \
   --mount /var/log/calico:/var/log/calico \


### PR DESCRIPTION
This PR adds MTU configuration option to calico for both IP-over-IP and workload interfaces.

Currently, there is no way to set Calico charm to use, for example jumbo frame. If we deploy calico on top of OpenStack, tunl0 (IP-IP tunnel) will always come with MTU: 1440 and workload interfaces will come up with MTU: 1500.

This PR allows to configure MTU following Calico's docs: https://docs.projectcalico.org/networking/mtu

Following comment on [1],  there are two places that demands changes: (1) we need to set the tunnel interface MTU whenever it is available. This is achieved by FELIX_IPINIPMTU option set on calico-node.service, as described in [2]; and we need to set workload interface MTUs on Calico's conflist (for information, those interfaces come with "cali..." nameprefix, as defined by FELIX_INTERFACEPREFIX [3])

Both setups are done using one single config option: veth-mtu.
If ipip config is set to anything other than Never, then workload MTU = tunl0 MTU - 50. Otherwise they'll have the same value.

[1] https://github.com/projectcalico/calicoctl/issues/488#issuecomment-294893504
[2] https://docs.projectcalico.org/reference/felix/configuration
[3] https://github.com/projectcalico/calico/blob/26c2d879f13c851d8fa3991240ffb4d86beefa38/reference/felix/configuration.md

Fixes: https://bugs.launchpad.net/charm-calico/+bug/1875322