### PR TITLE
Fix veth-mtu config issues

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,8 +28,13 @@ options:
     type: int
     default:
     description: |
-      Set veth MTU size for multiple scenarios. Users should follow instructions:
-      https://docs.projectcalico.org/networking/mtu
+      Set veth MTU size. This should be set to the MTU size of the base network.
+
+      If VXLAN is enabled, then the charm will automatically subtract 50 from the
+      specified MTU size.
+
+      If IPIP is enabled, then the charm will automatically subtract 20 from the
+      specified MTU size.
   nat-outgoing:
     type: boolean
     default: true

--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -240,18 +240,19 @@ def check_etcd_changes():
         remove_state('calico.npc.deployed')
 
 
-# overlay_interface stands for interfaces that are connected
-# directly to the pods. In Calico, they are prefixed as value set on
-# FELIX_INTERFACEPREFIX, which default is "cali..."
-def get_mtu(overlay_interface=False):
-    if not charm_config('veth-mtu'):
+def get_mtu():
+    ''' Get user-specified MTU size, adjusted to make room for encapsulation
+    headers. https://docs.projectcalico.org/networking/mtu
+    '''
+    mtu = charm_config('veth-mtu')
+    if not mtu:
         return None
-    if overlay_interface:
-        ipip_enabled = charm_config('ipip') != 'Never'
-        vxlan_enabled = charm_config('vxlan') != 'Never'
-        if ipip_enabled or vxlan_enabled:
-            return charm_config('veth-mtu') - 50
-    return charm_config('veth-mtu')
+
+    if charm_config('vxlan') != 'Never':
+        return mtu - 50
+    elif charm_config('ipip') != 'Never':
+        return mtu - 20
+    return mtu
 
 
 def get_bind_address():
@@ -299,7 +300,7 @@ def install_calico_service():
         # specify IP so calico doesn't grab a silly one from, say, lxdbr0
         'ip': ip4,
         'ip6': ip6,
-        'mtu': get_mtu(overlay_interface=False),
+        'mtu': get_mtu(),
         'calico_node_image': charm_config('calico-node-image'),
         'ignore_loose_rpf': charm_config('ignore-loose-rpf'),
     })
@@ -310,7 +311,6 @@ def install_calico_service():
 
 
 @when('config.changed.veth-mtu')
-@when('calico.cni.configured', 'calico.service.installed')
 def configure_mtu():
     remove_state('calico.service.installed')
     remove_state('calico.cni.configured')
@@ -404,7 +404,7 @@ def configure_cni():
         'etcd_cert_path': ETCD_CERT_PATH,
         'etcd_ca_path': ETCD_CA_PATH,
         'kubeconfig_path': cni_config['kubeconfig_path'],
-        'mtu': get_mtu(overlay_interface=True),
+        'mtu': get_mtu(),
         'assign_ipv4': 'true' if 4 in ip_versions else 'false',
         'assign_ipv6': 'true' if 6 in ip_versions else 'false',
     }


### PR DESCRIPTION
This fixes a variety of issues with the veth-mtu config. See https://bugs.launchpad.net/charm-calico/+bug/1901754

# Before this change

When using IPIP, with veth-mtu set to 9001, the cali* interfaces had MTU set to 8951, but the IPIP tunnel was incorrectly set to 9001:

```
$ ip link
...
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 06:bf:75:df:4c:a1 brd ff:ff:ff:ff:ff:ff
...
5: tunl0@NONE: <NOARP,UP,LOWER_UP> mtu 9001 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ipip 0.0.0.0 brd 0.0.0.0
10: calice4577962d9@if4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8951 qdisc noqueue state UP mode DEFAULT group default
    link/ether ee:ee:ee:ee:ee:ee brd ff:ff:ff:ff:ff:ff link-netns cni-edc19e83-917c-ac2a-944d-6700b061f843
...
```

Per the [upstream documentation](https://docs.projectcalico.org/networking/mtu), the minimum MTU should be used across the board, and their example at the end clearly shows that tunl0 MTU should *not* be equal to eth0 MTU.

# After this change

When using IPIP, with veth-mtu set to 9001, the cali* interfaces and IPIP tunnel now have MTU set to 8981:

```
$ ip link
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 02:c7:b9:96:c0:87 brd ff:ff:ff:ff:ff:ff
17: tunl0@NONE: <NOARP,UP,LOWER_UP> mtu 8981 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ipip 0.0.0.0 brd 0.0.0.0
32: cali34969d68091@if4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8981 qdisc noqueue state UP mode DEFAULT group default
    link/ether ee:ee:ee:ee:ee:ee brd ff:ff:ff:ff:ff:ff link-netns cni-9a4e57e6-dd42-3001-3136-8182c77c2138
```

When using VXLAN, with veth-mtu set to 9001, the cali* interfaces and VXLAN have MTU set to 8951:

```
$ ip link
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 02:c7:b9:96:c0:87 brd ff:ff:ff:ff:ff:ff
7: vxlan.calico: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8951 qdisc noqueue state UNKNOWN mode DEFAULT group default
    link/ether 66:3e:29:55:88:71 brd ff:ff:ff:ff:ff:ff
10: cali3157e7681f0@if3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8951 qdisc noqueue state UP mode DEFAULT group default
    link/ether ee:ee:ee:ee:ee:ee brd ff:ff:ff:ff:ff:ff link-netns cni-c4b19efa-155b-0491-d8dd-12d6fa9c0b66
```

# Other fixes

* Fixed misleading veth-mtu config description, which was directing users to a page that would have them adjust the MTU for encapsulation headers, even though the charm already handles this. (Thanks @johnsca for pointing this out!)
* Fixed changing veth-mtu config causing the charm to thrash, running the configure_mtu handler repeatedly.