### PR TITLE
Fix calico-node service failure on xenial due to ASCII locale

### DIFF
--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -303,6 +303,8 @@ def install_calico_service():
         'mtu': get_mtu(),
         'calico_node_image': charm_config('calico-node-image'),
         'ignore_loose_rpf': charm_config('ignore-loose-rpf'),
+        'lc_all': os.environ.get('LC_ALL', 'C.UTF-8'),
+        'lang': os.environ.get('LANG', 'C.UTF-8')
     })
     check_call(['systemctl', 'daemon-reload'])
     service_restart('calico-node')

--- a/templates/calico-node.service
+++ b/templates/calico-node.service
@@ -4,6 +4,10 @@ Description=calico node
 [Service]
 User=root
 Environment=ETCD_ENDPOINTS={{ connection_string }}
+# Setting LC_ALL and LANG works around a bug that only occurs on Xenial
+# https://bugs.launchpad.net/bugs/1911220
+Environment=LC_ALL={{ lc_all }}
+Environment=LANG={{ lang }}
 PermissionsStartOnly=true
 ExecStartPre=-/usr/local/sbin/charm-env --charm calico conctl delete calico-node
 ExecStartPre=/bin/mkdir -p /var/run/calico /var/log/calico /var/lib/calico


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/bugs/1911220 for Calico