### PR TITLE
pin click to < 8.0

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.5, 3.6, 3.7, 3.8]
+        python: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,1 +1,3 @@
 conctl-py35==0.1.2
+# pin click to avoid bringing in incompatible setuptools>=42
+click<8.0


### PR DESCRIPTION
Pin click to avoid getting an incompatible `setuptools` package on deploy.

Fixes https://bugs.launchpad.net/charm-calico/+bug/1929847