### PR TITLE
Upgrade to Calico 3.19

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@master
+        uses: charmed-kubernetes/actions-operator@main
         with:
           provider: vsphere
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -49,4 +49,4 @@ jobs:
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-options: "--model-default datastore=vsanDatastore --model-default primary-network=VLAN_2764"
       - name: Run test
-        run: tox -e integration
+        run: tox -e integration -- --destructive-mode

--- a/build-calico-resource.sh
+++ b/build-calico-resource.sh
@@ -10,8 +10,8 @@ set -eux
 
 # Supported calico architectures
 arches="amd64 arm64"
-calicoctl_version="v3.10.1"
-calico_cni_version="v3.10.1"
+calicoctl_version="v3.19.1"
+calico_cni_version="v3.19.1"
 
 function fetch_and_validate() {
   # fetch a binary and make sure it's what we expect (executable > 20MB)

--- a/build-calico-resource.sh
+++ b/build-calico-resource.sh
@@ -10,8 +10,8 @@ set -eux
 
 # Supported calico architectures
 arches="amd64 arm64"
-calicoctl_version="v3.19.1"
-calico_cni_version="v3.19.1"
+calicoctl_version="v3.19.3"
+calico_cni_version="v3.19.3"
 
 function fetch_and_validate() {
   # fetch a binary and make sure it's what we expect (executable > 20MB)

--- a/config.yaml
+++ b/config.yaml
@@ -17,15 +17,24 @@ options:
 
       Example value: ”10.0.0.0/24 10.0.1.0/24”
     default: ""
+  bgp-service-loadbalancer-ips:
+    type: string
+    description: |
+      Space-separated list of service load-balancer CIDRs to advertise over BGP.
+      These will be passed to the .spec.serviceLoadBalancerIPs field of the default
+      BGPConfiguration in Calico.
+
+      Example value: ”10.0.0.0/24 10.0.1.0/24”
+    default: ""
   calico-node-image:
     type: string
     # Please refer to layer-canal/versioning.md before changing the version below.
-    default: rocks.canonical.com:443/cdk/calico/node:v3.10.1
+    default: rocks.canonical.com:443/cdk/calico/node:v3.19.1
     description: |
       The image id to use for calico/node.
   calico-policy-image:
     type: string
-    default: rocks.canonical.com:443/cdk/calico/kube-controllers:v3.10.1
+    default: rocks.canonical.com:443/cdk/calico/kube-controllers:v3.19.1
     description: |
       The image id to use for calico/kube-controllers.
   ipip:

--- a/config.yaml
+++ b/config.yaml
@@ -29,12 +29,12 @@ options:
   calico-node-image:
     type: string
     # Please refer to layer-canal/versioning.md before changing the version below.
-    default: rocks.canonical.com:443/cdk/calico/node:v3.19.1
+    default: rocks.canonical.com:443/cdk/calico/node:v3.19.3
     description: |
       The image id to use for calico/node.
   calico-policy-image:
     type: string
-    default: rocks.canonical.com:443/cdk/calico/kube-controllers:v3.19.1
+    default: rocks.canonical.com:443/cdk/calico/kube-controllers:v3.19.3
     description: |
       The image id to use for calico/kube-controllers.
   ipip:

--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -529,6 +529,10 @@ def configure_bgp_globals():
             {'cidr': cidr}
             for cidr in config['bgp-service-external-ips'].split()
         ]
+        spec['serviceLoadBalancerIPs'] = [
+            {'cidr': cidr}
+            for cidr in config['bgp-service-loadbalancer-ips'].split()
+        ]
         calicoctl_apply(bgp_config)
     except CalledProcessError:
         log(traceback.format_exc())
@@ -541,7 +545,8 @@ def configure_bgp_globals():
 @when_any('config.changed.global-as-number',
           'config.changed.node-to-node-mesh',
           'config.changed.bgp-service-cluster-ips',
-          'config.changed.bgp-service-external-ips')
+          'config.changed.bgp-service-external-ips',
+          'config.changed.bgp-service-loadbalancer-ips')
 def reconfigure_bgp_globals():
     remove_state('calico.bgp.globals.configured')
 

--- a/templates/calico-node.service
+++ b/templates/calico-node.service
@@ -15,6 +15,7 @@ ExecStart=/usr/local/sbin/charm-env --charm calico conctl run \
   --rm \
   --net-host \
   --privileged \
+  --env DATASTORE_TYPE=etcdv3 \
   --env ETCD_ENDPOINTS={{ connection_string }} \
   --env ETCD_CA_CERT_FILE={{ etcd_ca_path }} \
   --env ETCD_CERT_FILE={{ etcd_cert_path }} \

--- a/templates/calico-node.service
+++ b/templates/calico-node.service
@@ -21,6 +21,7 @@ ExecStart=/usr/local/sbin/charm-env --charm calico conctl run \
   --env ETCD_CERT_FILE={{ etcd_cert_path }} \
   --env ETCD_KEY_FILE={{ etcd_key_path }} \
   --env NODENAME={{ nodename }} \
+  --env CALICO_K8S_NODE_REF={{ nodename }} \
   --env IP={{ ip }} \
   --env KUBECONFIG=/opt/calicoctl/kubeconfig \
   {% if ipv4 == "none" -%}

--- a/templates/policy-controller.yaml
+++ b/templates/policy-controller.yaml
@@ -4,6 +4,8 @@ metadata:
   name: calico-kube-controllers
   namespace: kube-system
 ---
+# Source: calico/templates/calico-kube-controllers-rbac.yaml
+
 # Include a clusterrole for the kube-controllers component,
 # and bind it to the calico-kube-controllers serviceaccount.
 kind: ClusterRole
@@ -14,20 +16,18 @@ rules:
   # Pods are monitored for changing labels.
   # The node controller monitors Kubernetes nodes.
   # Namespace and serviceaccount labels are used for policy.
-  - apiGroups: 
-    - ""
-    - extensions
+  - apiGroups: [""]
     resources:
       - pods
       - nodes
       - namespaces
       - serviceaccounts
-      - networkpolicies
     verbs:
       - watch
       - list
-  - apiGroups:
-    - networking.k8s.io
+      - get
+  # Watch for changes to Kubernetes NetworkPolicies.
+  - apiGroups: ["networking.k8s.io"]
     resources:
       - networkpolicies
     verbs:
@@ -47,6 +47,8 @@ subjects:
   name: calico-kube-controllers
   namespace: kube-system
 ---
+# Source: calico/templates/calico-kube-controllers.yaml
+# See https://github.com/projectcalico/kube-controllers
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -56,14 +58,11 @@ metadata:
     k8s-app: calico-kube-controllers
     cdk-restart-on-ca-change: "true"
 spec:
-  # Only a single instance of the this pod should be
-  # active at a time.  Since this pod is run as a Deployment,
-  # Kubernetes will ensure the pod is recreated in case of failure,
-  # removing the need for passive backups.
+  # The controllers can only have a single active instance.
+  replicas: 1
   selector:
     matchLabels:
       k8s-app: calico-kube-controllers
-  replicas: 1
   strategy:
     type: Recreate
   template:
@@ -77,8 +76,19 @@ spec:
         # will restart the pod
         cdk-etcd-cert-last-modified: "{{ etcd_cert_last_modified }}"
     spec:
-      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
       serviceAccountName: calico-kube-controllers
+      priorityClassName: system-cluster-critical
+      # The controllers must run in the host network namespace so that
+      # it isn't governed by policy that would prevent it from working.
+      hostNetwork: true
       containers:
         - name: calico-kube-controllers
           image: {{ calico_policy_image }}
@@ -91,14 +101,34 @@ spec:
               value: {{ etcd_cert_path }}
             - name: ETCD_KEY_FILE
               value: {{ etcd_key_path }}
+            # Choose which controllers to run.
+            - name: ENABLED_CONTROLLERS
+              value: policy,namespace,serviceaccount,workloadendpoint,node
           volumeMounts:
             - name: calicoctl
               mountPath: /opt/calicoctl
+          livenessProbe:
+            exec:
+              command:
+              - /usr/bin/check-status
+              - -l
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+              - /usr/bin/check-status
+              - -r
+            periodSeconds: 10
       volumes:
         - name: calicoctl
           hostPath:
             path: /opt/calicoctl
 ---
+# Source: calico/templates/calico-node-rbac.yaml
+# Include a clusterrole for the calico-node DaemonSet,
+# and bind it to the calico-node serviceaccount.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -120,7 +150,11 @@ rules:
       # Used to discover service IPs for advertisement.
       - watch
       - list
-      # Used to discover Typhas.
+  # Pod CIDR auto-detection on kubeadm needs access to config maps.
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs:
       - get
   - apiGroups: [""]
     resources:
@@ -128,107 +162,6 @@ rules:
     verbs:
       # Needed for clearing NodeNetworkUnavailable flag.
       - patch
-      # Calico stores some configuration information in node annotations.
-      - update
-  # Watch for changes to Kubernetes NetworkPolicies.
-  - apiGroups: ["networking.k8s.io"]
-    resources:
-      - networkpolicies
-    verbs:
-      - watch
-      - list
-  # Used by Calico for policy information.
-  - apiGroups: [""]
-    resources:
-      - pods
-      - namespaces
-      - serviceaccounts
-    verbs:
-      - list
-      - watch
-  # The CNI plugin patches pods/status.
-  - apiGroups: [""]
-    resources:
-      - pods/status
-    verbs:
-      - patch
-  # Calico monitors various CRDs for config.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - globalfelixconfigs
-      - felixconfigurations
-      - bgppeers
-      - globalbgpconfigs
-      - bgpconfigurations
-      - ippools
-      - ipamblocks
-      - globalnetworkpolicies
-      - globalnetworksets
-      - networkpolicies
-      - networksets
-      - clusterinformations
-      - hostendpoints
-      - blockaffinities
-    verbs:
-      - get
-      - list
-      - watch
-  # Calico must create and update some CRDs on startup.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - ippools
-      - felixconfigurations
-      - clusterinformations
-    verbs:
-      - create
-      - update
-  # Calico stores some configuration information on the node.
-  - apiGroups: [""]
-    resources:
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-  # These permissions are only requried for upgrade from v2.6, and can
-  # be removed after upgrade or on fresh installations.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - bgpconfigurations
-      - bgppeers
-    verbs:
-      - create
-      - update
-  # These permissions are required for Calico CNI to perform IPAM allocations.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - blockaffinities
-      - ipamblocks
-      - ipamhandles
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - ipamconfigs
-    verbs:
-      - get
-  # Block affinities must also be watchable by confd for route aggregation.
-  - apiGroups: ["crd.projectcalico.org"]
-    resources:
-      - blockaffinities
-    verbs:
-      - watch
-  # The Calico IPAM migration needs to get daemonsets. These permissions can be
-  # removed if not upgrading from an installation using host-local IPAM.
-  - apiGroups: ["apps"]
-    resources:
-      - daemonsets
-    verbs:
-      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
See [final commit](https://github.com/charmed-kubernetes/layer-calico/commit/a4867b373e90badcd9536d7a5219a446924998f5). The other commits are just carry-over from https://github.com/charmed-kubernetes/layer-calico/pull/70.

This is what I think is needed to upgrade to Calico 3.19.1. I don't want to grow the scope of the BGP service IP work yet again, so I'm opening this draft PR instead as a reference for when we're ready to do the upgrade proper.