### PR TITLE
Remove master/worker check, always render CNI config

### DIFF
--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -439,12 +439,12 @@ def reconfigure_calico_pool():
     remove_state('calico.pool.configured')
 
 
-@when('etcd.available', 'cni.is-worker', 'leadership.set.calico-v3-data-ready')
+@when('etcd.available', 'cni.connected', 'leadership.set.calico-v3-data-ready')
 @when_not('calico.cni.configured')
 def configure_cni():
     ''' Configure Calico CNI. '''
     status.maintenance('Configuring Calico CNI')
-    cni = endpoint_from_flag('cni.is-worker')
+    cni = endpoint_from_flag('cni.connected')
     etcd = endpoint_from_flag('etcd.available')
     os.makedirs('/etc/cni/net.d', exist_ok=True)
     ip_versions = {net.version for net in get_networks(charm_config('cidr'))}
@@ -459,16 +459,6 @@ def configure_cni():
         'assign_ipv6': 'true' if 6 in ip_versions else 'false',
     }
     render('10-calico.conflist', '/etc/cni/net.d/10-calico.conflist', context)
-    config = charm_config()
-    cni.set_config(cidr=config['cidr'], cni_conf_file='10-calico.conflist')
-    set_state('calico.cni.configured')
-
-
-@when('etcd.available', 'cni.is-master')
-@when_not('calico.cni.configured')
-def configure_master_cni():
-    status.maintenance('Configuring Calico CNI')
-    cni = endpoint_from_flag('cni.is-master')
     config = charm_config()
     cni.set_config(cidr=config['cidr'], cni_conf_file='10-calico.conflist')
     set_state('calico.cni.configured')

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,12 @@ deps =
 commands = pytest --tb native -s {posargs} {toxinidir}/tests/unit
 
 [testenv:validate-wheelhouse]
+deps =
+# Temporarily pin setuptools to avoid the breaking change from 58 until
+# all dependencies we use have a chance to update. (tempita is the troublemaker for this repo).
+# See: https://setuptools.readthedocs.io/en/latest/history.html#v58-0-0
+# and: https://github.com/pypa/setuptools/issues/2784#issuecomment-917663223
+    setuptools<58
 allowlist_externals = {toxinidir}/tests/validate-wheelhouse.sh
 commands = {toxinidir}/tests/validate-wheelhouse.sh
 


### PR DESCRIPTION
This is needed to support adding kubelet to kubernetes-master.