### PR TITLE
Fix calico-node spamming cni-config-monitor errors

### DIFF
--- a/build-calico-resource.sh
+++ b/build-calico-resource.sh
@@ -86,9 +86,12 @@ for arch in ${arches}; do
 
     # arm64 builds are failing due to an upstream issue:
     # https://github.com/projectcalico/calico-upgrade/issues/42
-    # For now, we will pull a previously built binary from the charm store.
-    wget https://api.jujucharms.com/charmstore/v5/~containers/calico-698/resource/calico-upgrade-arm64/462 \
-      -O calico-upgrade-arm64.tar.gz
+    # For now, we will pull a previously built binary from charmhub.
+    url="$(wget -O- \
+      'https://api.charmhub.io/v2/charms/info/calico?channel=latest/edge&fields=default-release.resources' \
+      | jq -r '."default-release".resources[] | select(.name == "calico-upgrade-arm64").download.url'
+    )"
+    wget "$url" -O calico-upgrade-arm64.tar.gz
     tar -xf calico-upgrade-arm64.tar.gz
     checksum="$(sha256sum calico-upgrade)"
     if [ "$checksum" != "7a07816c26ad19f526ab2f57353043dabd708a48185268b41493e458c59b797d  calico-upgrade" ]; then

--- a/templates/calico-node.service
+++ b/templates/calico-node.service
@@ -41,6 +41,7 @@ ExecStart=/usr/local/sbin/charm-env --charm calico conctl run \
   --env FELIX_IPINIPMTU={{ mtu }} \
   --env FELIX_VXLANMTU={{ mtu }} \
   {% endif -%}
+  --env CALICO_MANAGE_CNI=false \
   --mount /lib/modules:/lib/modules \
   --mount /var/run/calico:/var/run/calico \
   --mount /var/log/calico:/var/log/calico \

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -9,16 +9,16 @@ machines:
     series: focal
 services:
   containerd:
-    charm: cs:~containers/containerd
+    charm: containerd
     channel: edge
   easyrsa:
-    charm: cs:~containers/easyrsa
+    charm: easyrsa
     channel: edge
     num_units: 1
     to:
     - '1'
   etcd:
-    charm: cs:~containers/etcd
+    charm: etcd
     channel: edge
     num_units: 1
     options:
@@ -43,17 +43,17 @@ services:
     expose: true
     num_units: 1
     options:
-      channel: 1.22/edge
+      channel: 1.23/edge
     to:
     - '0'
   kubernetes-worker:
-    charm: cs:~containers/kubernetes-worker
+    charm: kubernetes-worker
     channel: edge
     constraints: cores=4 mem=4G root-disk=16G
     expose: true
     num_units: 1
     options:
-      channel: 1.22/edge
+      channel: 1.23/edge
     to:
     - '1'
 relations:


### PR DESCRIPTION
While testing Calico 3.21 on LXD, I noticed this error spam coming from calico-node:

```
2022-02-14 19:55:12.116 [ERROR][53] cni-config-monitor/token_watch.go 34: Failed to watch Kubernetes serviceaccount files. error=no such file or directory
2022-02-14 19:55:17.117 [ERROR][53] cni-config-monitor/token_watch.go 34: Failed to watch Kubernetes serviceaccount files. error=no such file or directory
2022-02-14 19:55:22.117 [ERROR][53] cni-config-monitor/token_watch.go 34: Failed to watch Kubernetes serviceaccount files. error=no such file or directory
```

This [upstream PR](https://github.com/projectcalico/node/pull/344) indicates that the error is part of CNI token watch code that only runs when `CALICO_MANAGE_CNI=true`.

From the [calico-node reference docs](https://projectcalico.docs.tigera.io/archive/v3.21/reference/node/configuration), the `CALICO_MANAGE_CNI` option has the following description:

> Tells Calico to update the kubeconfig file at /host/etc/cni/net.d/calico-kubeconfig on credentials change. [Default: true]

We don't need this because the Calico charm writes and maintains its own CNI kubeconfig [here](https://github.com/charmed-kubernetes/layer-calico/blob/0d69df417f0ee74cefcc3d7ceba71919191e459f/reactive/calico.py#L323-L334).

To fix this, we set `CALICO_MANAGE_CNI=false`. I've confirmed that doing so makes the error go away.