### PR TITLE
Add charmcraft.yaml to test bird charm

### DIFF
--- a/tests/data/bird-operator/charmcraft.yaml
+++ b/tests/data/bird-operator/charmcraft.yaml
@@ -1,0 +1,4 @@
+type: charm
+bases:
+- name: ubuntu
+  channel: "20.04"


### PR DESCRIPTION
Fixes build failures with Charmcraft 1.5.0. `charmcraft.yaml` is required now.