### PR TITLE
Add check for rp_filter conflict with ignore-loose-rpf config

### DIFF
--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -29,8 +29,7 @@ from charmhelpers.core.host import (
     arch,
     service,
     service_restart,
-    service_running,
-    lsb_release
+    service_running
 )
 from charmhelpers.core.templating import render
 from charms.layer import kubernetes_common, status
@@ -759,13 +758,11 @@ def get_networks(cidrs):
 
 
 def is_rpf_config_mismatched():
-    # This check should only apply on focal and above
-    release = lsb_release()
-    release_number = float(release['DISTRIB_RELEASE'])
-    if release_number >= 20.04:
-        with open('/proc/sys/net/ipv4/conf/all/rp_filter') as f:
-            rp_filter = int(f.read())
-        ignore_loose_rpf = charm_config('ignore-loose-rpf')
-        if rp_filter != 1 and not ignore_loose_rpf:
-            return True
+    with open('/proc/sys/net/ipv4/conf/all/rp_filter') as f:
+        rp_filter = int(f.read())
+    ignore_loose_rpf = charm_config('ignore-loose-rpf')
+    if rp_filter == 2 and not ignore_loose_rpf:
+        # calico says this is invalid
+        # https://github.com/kubernetes-sigs/kind/issues/891
+        return True
     return False

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,14 +1,14 @@
 from kubernetes_wrapper import Kubernetes
 import logging
 import pytest
+import pytest_asyncio
 import random
 import string
 
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="module")
-@pytest.mark.asyncio
+@pytest_asyncio.fixture(scope="module")
 async def kubernetes(ops_test):
     kubeconfig_path = ops_test.tmp_path / "kubeconfig"
     retcode, stdout, stderr = await ops_test.run(

--- a/tests/unit/test_calico.py
+++ b/tests/unit/test_calico.py
@@ -1,6 +1,8 @@
-from charmhelpers.core.hookenv import is_leader  # patched
+from charmhelpers.core.hookenv import is_leader, config  # patched
 from charmhelpers.core.host import service_running  # patched
+from charmhelpers.core.host import lsb_release  # patched
 from reactive import calico
+from unittest.mock import patch, mock_open
 
 
 def test_series_upgrade():
@@ -14,3 +16,59 @@ def test_series_upgrade():
     assert calico.status.blocked.call_count == 1
     assert calico.status.waiting.call_count == 0
     assert calico.status.active.call_count == 0
+    calico.remove_state('upgrade.series.in-progress')
+
+
+def test_ignore_loose_rpf_at_exit():
+    # Test case where release is less than 20.04
+    with patch("builtins.open", mock_open(read_data="1")):
+        calico.status.reset_mock()
+        lsb_release.return_value = {"DISTRIB_RELEASE": "18.04"}
+        calico.ready()
+        assert calico.status.blocked.call_count == 0
+
+    # Test the case when charm should be blocked
+    # i.e. when rp filter != 1 and ignore-loose-rpf is false
+    with patch("builtins.open", mock_open(read_data="2")):
+        calico.status.reset_mock()
+        # config.return value returns the config setting for ignore-loose-rpf
+        config.return_value = False
+        lsb_release.return_value = {"DISTRIB_RELEASE": "20.04"}
+        calico.ready()
+        assert calico.status.blocked.call_count == 1
+
+    # Test above case with release greater than 20.04
+    with patch("builtins.open", mock_open(read_data="2")):
+        calico.status.reset_mock()
+        # config.return value returns the config setting for ignore-loose-rpf
+        config.return_value = False
+        lsb_release.return_value = {"DISTRIB_RELEASE": "21.04"}
+        calico.ready()
+        assert calico.status.blocked.call_count == 1
+
+    # Test the case when rp filter == 1 and ignore-loose-rpf is false
+    with patch("builtins.open", mock_open(read_data="1")):
+        calico.status.reset_mock()
+        # config.return value returns the config setting for ignore-loose-rpf
+        config.return_value = False
+        lsb_release.return_value = {"DISTRIB_RELEASE": "20.04"}
+        calico.ready()
+        assert calico.status.blocked.call_count == 0
+
+    # Test the case when rp filter != 1 and ignore-loose-rpf is true
+    with patch("builtins.open", mock_open(read_data="2")):
+        calico.status.reset_mock()
+        # config.return value returns the config setting for ignore-loose-rpf
+        config.return_value = True
+        lsb_release.return_value = {"DISTRIB_RELEASE": "20.04"}
+        calico.ready()
+        assert calico.status.blocked.call_count == 0
+
+    # Test the case when rp filter == 1 and ignore-loose-rpf is true
+    with patch("builtins.open", mock_open(read_data="1")):
+        calico.status.reset_mock()
+        # config.return value returns the config setting for ignore-loose-rpf
+        config.return_value = True
+        lsb_release.return_value = {"DISTRIB_RELEASE": "20.04"}
+        calico.ready()
+        assert calico.status.blocked.call_count == 0

--- a/tests/unit/test_calico.py
+++ b/tests/unit/test_calico.py
@@ -1,6 +1,5 @@
 from charmhelpers.core.hookenv import is_leader, config  # patched
 from charmhelpers.core.host import service_running  # patched
-from charmhelpers.core.host import lsb_release  # patched
 from reactive import calico
 from unittest.mock import patch, mock_open
 
@@ -20,55 +19,35 @@ def test_series_upgrade():
 
 
 def test_ignore_loose_rpf_at_exit():
-    # Test case where release is less than 20.04
-    with patch("builtins.open", mock_open(read_data="1")):
-        calico.status.reset_mock()
-        lsb_release.return_value = {"DISTRIB_RELEASE": "18.04"}
-        calico.ready()
-        assert calico.status.blocked.call_count == 0
-
     # Test the case when charm should be blocked
-    # i.e. when rp filter != 1 and ignore-loose-rpf is false
+    # i.e. when rp filter == 2 and ignore-loose-rpf is false
     with patch("builtins.open", mock_open(read_data="2")):
         calico.status.reset_mock()
         # config.return value returns the config setting for ignore-loose-rpf
         config.return_value = False
-        lsb_release.return_value = {"DISTRIB_RELEASE": "20.04"}
         calico.ready()
         assert calico.status.blocked.call_count == 1
 
-    # Test above case with release greater than 20.04
-    with patch("builtins.open", mock_open(read_data="2")):
-        calico.status.reset_mock()
-        # config.return value returns the config setting for ignore-loose-rpf
-        config.return_value = False
-        lsb_release.return_value = {"DISTRIB_RELEASE": "21.04"}
-        calico.ready()
-        assert calico.status.blocked.call_count == 1
-
-    # Test the case when rp filter == 1 and ignore-loose-rpf is false
+    # Test the case when rp filter != 2 and ignore-loose-rpf is false
     with patch("builtins.open", mock_open(read_data="1")):
         calico.status.reset_mock()
         # config.return value returns the config setting for ignore-loose-rpf
         config.return_value = False
-        lsb_release.return_value = {"DISTRIB_RELEASE": "20.04"}
         calico.ready()
         assert calico.status.blocked.call_count == 0
 
-    # Test the case when rp filter != 1 and ignore-loose-rpf is true
+    # Test the case when rp filter == 2 and ignore-loose-rpf is true
     with patch("builtins.open", mock_open(read_data="2")):
         calico.status.reset_mock()
         # config.return value returns the config setting for ignore-loose-rpf
         config.return_value = True
-        lsb_release.return_value = {"DISTRIB_RELEASE": "20.04"}
         calico.ready()
         assert calico.status.blocked.call_count == 0
 
-    # Test the case when rp filter == 1 and ignore-loose-rpf is true
+    # Test the case when rp filter != 2 and ignore-loose-rpf is true
     with patch("builtins.open", mock_open(read_data="1")):
         calico.status.reset_mock()
         # config.return value returns the config setting for ignore-loose-rpf
         config.return_value = True
-        lsb_release.return_value = {"DISTRIB_RELEASE": "20.04"}
         calico.ready()
         assert calico.status.blocked.call_count == 0

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ deps =
 # tox only passes through the upper-case versions by default, but some
 # programs, such as wget or pip, only honor the lower-case versions
 passenv = http_proxy https_proxy no_proxy
-commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
+commands = pytest --asyncio-mode=auto --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
This PR adds a check for conflicting configuration of the ignore-loose-rpf config value with the systems rp_filter value in response to the following bug: https://bugs.launchpad.net/charm-calico/+bug/1895547

if OS>=focal and ignore-loose-rpf=false and rp_filter != 1, then the charm will show a blocked status indicating there is a conflict with the config. 

Unit tests and integration tests for this check have also been added. 
