### PR TITLE
Switch to using v1 API for PDB

### DIFF
--- a/templates/policy-controller.yaml
+++ b/templates/policy-controller.yaml
@@ -216,6 +216,7 @@ metadata:
 
 # This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
 
+# CK edit: PodDisruptionBudget policy/v1beta1 is no longer served in k8s 1.25. Use policy/v1 instead, available since k8s 1.21
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/templates/policy-controller.yaml
+++ b/templates/policy-controller.yaml
@@ -216,7 +216,7 @@ metadata:
 
 # This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
 
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: calico-kube-controllers


### PR DESCRIPTION
[PodDisruptionBudget v1beta1 API](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125) is removed in 1.25. The v1 API supports 1.21+. 