### PR TITLE
Update Calico to v3.25.1

### DIFF
--- a/build-calico-resource.sh
+++ b/build-calico-resource.sh
@@ -10,7 +10,7 @@ set -eux
 
 # Supported calico architectures
 arches="amd64 arm64"
-calico_version="v3.21.4"
+calico_version="v3.25.1"
 
 function fetch_and_validate() {
   # fetch a binary and make sure it's what we expect (executable > 20MB)

--- a/config.yaml
+++ b/config.yaml
@@ -29,12 +29,12 @@ options:
   calico-node-image:
     type: string
     # Please refer to layer-canal/versioning.md before changing the version below.
-    default: rocks.canonical.com:443/cdk/calico/node:v3.21.4
+    default: rocks.canonical.com:443/cdk/calico/node:v3.25.1
     description: |
       The image id to use for calico/node.
   calico-policy-image:
     type: string
-    default: rocks.canonical.com:443/cdk/calico/kube-controllers:v3.21.4
+    default: rocks.canonical.com:443/cdk/calico/kube-controllers:v3.25.1
     description: |
       The image id to use for calico/kube-controllers.
   ipip:

--- a/templates/policy-controller.yaml
+++ b/templates/policy-controller.yaml
@@ -1,16 +1,17 @@
 # Calico manifest for Charmed Kubernetes.
 #
-# Pulled from upstream on 2022-01-24 at
-# https://docs.projectcalico.org/archive/v3.21/manifests/calico-etcd.yaml
+# Pulled from upstream on 2023-05-26 at
+# https://github.com/projectcalico/calico/blob/v3.25.1/manifests/calico-etcd.yaml
 #
 # Search "CK edit" to find all the changes that were made for this charm.
+---
+# CK edit: Remove the calico-node ServiceAccount
 ---
 # CK edit: Remove calico-etcd-secrets secret
 ---
 # CK edit: Remove calico-config ConfigMap
 ---
 # Source: calico/templates/calico-kube-controllers-rbac.yaml
-
 # Include a clusterrole for the kube-controllers component,
 # and bind it to the calico-kube-controllers serviceaccount.
 kind: ClusterRole
@@ -38,21 +39,6 @@ rules:
     verbs:
       - watch
       - list
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: calico-kube-controllers
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: calico-kube-controllers
-subjects:
-- kind: ServiceAccount
-  name: calico-kube-controllers
-  namespace: kube-system
----
-
 ---
 # Source: calico/templates/calico-node-rbac.yaml
 # Include a clusterrole for the calico-node DaemonSet,
@@ -100,6 +86,21 @@ rules:
       - patch
 
 ---
+# Source: calico/templates/calico-kube-controllers-rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-kube-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-kube-controllers
+subjects:
+- kind: ServiceAccount
+  name: calico-kube-controllers
+  namespace: kube-system
+---
+# Source: calico/templates/calico-node-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -115,8 +116,6 @@ subjects:
 
 ---
 # CK edit: Remove the calico-node DaemonSet
----
-# CK edit: Remove the calico-node ServiceAccount
 ---
 # Source: calico/templates/calico-kube-controllers.yaml
 # See https://github.com/projectcalico/kube-controllers
@@ -157,6 +156,8 @@ spec:
           operator: Exists
         # wokeignore:rule=master - CK edit: pass woke check
         - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
       priorityClassName: system-cluster-critical
@@ -205,7 +206,7 @@ spec:
           hostPath:
             path: /opt/calicoctl
 ---
-
+# Source: calico/templates/calico-kube-controllers.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -213,10 +214,9 @@ metadata:
   namespace: kube-system
 
 ---
-
+# Source: calico/templates/calico-kube-controllers.yaml
 # This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
 
-# CK edit: PodDisruptionBudget policy/v1beta1 is no longer served in k8s 1.25. Use policy/v1 instead, available since k8s 1.21
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -229,14 +229,3 @@ spec:
   selector:
     matchLabels:
       k8s-app: calico-kube-controllers
-
----
-# Source: calico/templates/calico-typha.yaml
-
----
-# Source: calico/templates/configure-canal.yaml
-
----
-# Source: calico/templates/kdd-crds.yaml
-
-

--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -1,7 +1,8 @@
 description: A minimal two-machine Kubernetes cluster, appropriate for development.
 series: &series {{ series }}
-services:
+applications:
   calico:
+    channel: null
     charm: {{calico_charm}}
     resources:
       calico: {{resource_path}}/calico-amd64.tar.gz


### PR DESCRIPTION
# Summary
This PR proposes an update for Calico to v3.25.1
## Changes
- Update `calico_version` in the build-calico-resource.sh script.
- Update images `calico/node`, `calico/kube-controllers` to `v3.25.1`
- Update `policy-controller.yaml` and made the necessary edits in the `v3.25.1` manifest from upstream.
## Images
```
# calico/node
{"name":"cdk/calico/node","tags":["v2.6.12","v3.10.1","v3.15.5","v3.18.4","v3.19.1","v3.19.3","v3.21.4","v3.25.1","v3.6.1"]}

# calico/kube-controllers
{"name":"cdk/calico/kube-controllers","tags":["v1.0.5","v3.10.1","v3.15.5","v3.18.4","v3.19.1","v3.19.3","v3.21.4","v3.25.1","v3.6.1"]}
```
## Related bugs
[LP #2020695](https://bugs.launchpad.net/charm-calico/+bug/2020695)