### PR TITLE
Pin setuptools used for noble and jammy

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -212,7 +212,7 @@ actions:
         type: string
         default: ""
         description: |
-          Space separated list of kubernetes resource types to filter scrubbing   
+          Space separated list of kubernetes resource types to filter scrubbing
   sync-resources:
     description: |
       Add kubernetes resources which should be created by this charm which aren't
@@ -248,7 +248,6 @@ parts:
     plugin: charm
     source: .
     build-packages: [git]
-    charm-python-packages: [setuptools]
     prime:
       - upstream/**
       - scripts/**

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ops >= 2.2.0
 lightkube
 ops.manifest >= 1.1.0
-git+https://github.com/charmed-kubernetes/conctl@c1eaaac#egg=conctl
+conctl @ git+https://github.com/charmed-kubernetes/conctl@c1eaaac#egg=conctl
+setuptools == 79.0.1


### PR DESCRIPTION
* pins setuptools used by python 3.10 and 3.12 
* overrides charmcraft 2.x's default of `setuptools-59.6.0`

Similar to:
* https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/385
* https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/191
* https://github.com/charmed-kubernetes/charm-kubernetes-e2e/pull/40
* https://github.com/charmed-kubernetes/charm-kubeapi-load-balancer/pull/46
* https://github.com/charmed-kubernetes/charm-kube-ovn/pull/60