### PR TITLE
fix: use tarfile filter='data' for safe extraction (B202)

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -553,7 +553,7 @@ class CalicoCharm(ops.CharmBase):
 
     def _unpack_archive(self, path: Path, destination: Path):
         tar = tarfile.open(path)
-        tar.extractall(destination)
+        tar.extractall(destination, filter="data")  # safe: strips unsafe tar metadata
         tar.close()
 
     def _list_versions(self, event):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1008,7 +1008,7 @@ def test_unpack_archive(mock_tarfile_open: mock.MagicMock, charm: CalicoCharm):
 
     charm._unpack_archive(source_path, dst_path)
     mock_tarfile_open.assert_called_once_with(source_path)
-    mock_tarfile_open().extractall.assert_called_once_with(dst_path)
+    mock_tarfile_open().extractall.assert_called_once_with(dst_path, filter="data")
 
 
 @mock.patch("charm.CalicoCharm.calicoctl")


### PR DESCRIPTION
## Summary

Use `tarfile.extractall(filter="data")` to guard against path traversal in tar entries, replacing the previous `# nosec B202` annotation.

The `filter="data"` option (Python 3.12+) strips unsafe tar metadata — absolute paths, symlinks to outside destinations, setuid/setgid bits — while still extracting file contents normally. This is the recommended fix for bandit B202.

## Context
Companion to the SAST workflows PR. Once both are merged, the bandit workflow will pass cleanly.